### PR TITLE
Add pyshortcuts as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,11 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    ]
-dependencies = ["wxPython>=4.1.0"]
+]
+dependencies = [
+    "wxPython>=4.1.0",
+    "pyshortcuts",
+]
 [project.urls]
 Homepage = "https://github.com/newville/wxutils"
 Documentation ="https://github.com/newville/wxutils"


### PR DESCRIPTION
A previous [commit](https://github.com/newville/wxutils/commit/7b6ee1766f142ddf0d77920d7d5919d7dd7d7754) for version 0.3.6 broke the conda-forge feedstock. This fixes #1